### PR TITLE
feat: use ports returned via API and fallback to seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Documentation
 
-You can find installation instructions and detailed instructions on how to use this package at the [dedicated documentation site](.).
+You can find installation instructions and detailed instructions on how to use this package at the [dedicated documentation site](https://docs.ark.io/exchanges/json-rpc.html).
 
 ## Security
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "exchange-json-rpc",
-    "description": "The packages that make up the ARK Core",
+    "description": "A JSON-RPC 2.0 specification compliant server for Exchanges.",
     "scripts": {
         "lerna": "./node_modules/lerna/cli.js",
         "setup": "yarn && yarn bootstrap && yarn build",

--- a/packages/rpc/src/interfaces.ts
+++ b/packages/rpc/src/interfaces.ts
@@ -27,3 +27,8 @@ export interface IWallet {
     keys: Interfaces.IKeyPair;
     wif: string;
 }
+
+export interface IPeer {
+    ip: string;
+    port: number;
+}

--- a/packages/rpc/src/server/index.ts
+++ b/packages/rpc/src/server/index.ts
@@ -67,7 +67,7 @@ export async function startServer(options: Record<string, string | number | bool
 
     await server.start();
 
-    logger.info(`Server running on ${server.info.uri}`);
+    logger.info(`Exchange JSON-RPC running on ${server.info.uri}`);
 
     return server;
 }

--- a/packages/rpc/src/services/network.ts
+++ b/packages/rpc/src/services/network.ts
@@ -80,7 +80,7 @@ class Network {
     private async getPeers(): Promise<IPeer[]> {
         const { data } = await this.sendRequest("get", "peers", {}, 0, true);
 
-        if (!data.length) {
+        if (!data || !data.length) {
             return this.seeds;
         }
 

--- a/packages/rpc/src/services/network.ts
+++ b/packages/rpc/src/services/network.ts
@@ -2,15 +2,19 @@ import { httpie } from "@arkecosystem/core-utils";
 import { Managers, Types } from "@arkecosystem/crypto";
 import isReachable from "is-reachable";
 import sample from "lodash.sample";
+import { IPeer } from "../interfaces";
 import { logger } from "./logger";
 
 class Network {
     private opts: { network: string; peer: string };
+    private seeds: IPeer[] = [];
 
-    public async init(opts: { network: Types.NetworkName; peer: string }) {
+    public async init(opts: { network: Types.NetworkName; peer: string }): Promise<void> {
         this.opts = opts;
 
         Managers.configManager.setFromPreset(opts.network);
+
+        await this.loadSeeds();
     }
 
     public async sendGET({ path, query = {} }: { path: string; query?: Record<string, any> }) {
@@ -21,9 +25,9 @@ class Network {
         return this.sendRequest("post", path, { body });
     }
 
-    private async sendRequest(method: string, url: string, opts, tries: number = 0) {
+    private async sendRequest(method: string, url: string, opts, tries: number = 0, useSeed: boolean = false) {
         try {
-            const peer: { ip: string; port: number } = await this.getPeer();
+            const peer: IPeer = await this.getPeer(useSeed);
             const uri: string = `http://${peer.ip}:${peer.port}/api/${url}`;
 
             logger.info(`Sending request on "${this.opts.network}" to "${uri}"`);
@@ -41,23 +45,27 @@ class Network {
         } catch (error) {
             logger.error(error.message);
 
-            if (tries > 3) {
+            tries++;
+
+            if (tries > 2) {
                 logger.error(`Failed to find a responsive peer after 3 tries.`);
                 return undefined;
             }
-
-            tries++;
 
             return this.sendRequest(method, url, opts, tries);
         }
     }
 
-    private async getPeer(): Promise<{ ip: string; port: number }> {
+    private async getPeer(useSeed: boolean = false): Promise<IPeer> {
         if (this.opts.peer) {
             return { ip: this.opts.peer, port: 4003 };
         }
 
-        const peer: { ip: string; port: number } = sample(await this.getPeers());
+        if (useSeed) {
+            return sample(this.seeds);
+        }
+
+        const peer: IPeer = sample(await this.getPeers());
         const reachable: boolean = await isReachable(`${peer.ip}:${peer.port}`);
 
         if (!reachable) {
@@ -69,20 +77,44 @@ class Network {
         return peer;
     }
 
-    private async getPeers(): Promise<Array<{ ip: string; port: number }>> {
-        const { body } = await httpie.get(
+    private async getPeers(): Promise<IPeer[]> {
+        const { data } = await this.sendRequest("get", "peers", {}, 0, true);
+
+        if (!data.length) {
+            return this.seeds;
+        }
+
+        const peers: IPeer[] = [];
+
+        for (const peer of data) {
+            const pluginName: string = Object.keys(peer.ports).find((key: string) => key.split("/")[1] === "core-api");
+
+            if (pluginName) {
+                const port: number = peer.ports[pluginName];
+
+                if (port >= 1 && port <= 65535) {
+                    peers.push({ ip: peer.ip, port });
+                }
+            }
+        }
+
+        return peers;
+    }
+
+    private async loadSeeds(): Promise<void> {
+        const { body: seeds } = await httpie.get(
             `https://raw.githubusercontent.com/ArkEcosystem/peers/master/${this.opts.network}.json`,
         );
 
-        if (!body.length) {
-            throw new Error("No peers found. Shutting down...");
+        if (!seeds.length) {
+            throw new Error("No seeds found");
         }
 
-        for (const peer of body) {
-            peer.port = 4003; // @TODO
+        for (const seed of seeds) {
+            seed.port = 4003;
         }
 
-        return body;
+        this.seeds = seeds;
     }
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Make use of the new `ports` property in Core 2.4.0 to detect the API port instead of hardcoding it and add a fallback to seeds if no peers are found.

Resolves https://github.com/ArkEcosystem/exchange-json-rpc/issues/18

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
