### PR TITLE
fix: node fees

### DIFF
--- a/packages/rpc/src/server/utils.ts
+++ b/packages/rpc/src/server/utils.ts
@@ -76,7 +76,7 @@ export const buildTransaction = async (
                 path: "node/fees",
             });
 
-            const fee: string = data.find(({ type }) => type === 0).avg;
+            const fee: string = data[1].transfer.avg;
 
             if (fee && Number(fee) > 0) {
                 transactionBuilder.fee(fee);


### PR DESCRIPTION
Simple fix for the node/fees endpoint. 

Not sure if we want it like this for the json rpc, as the alternative solution would be to make use of the enums to get something like `data[Enums.TransactionTypeGroup.Core][Enums.TransactionType.Transfer].avg` 🤔 