### PR TITLE
feat: pre aip11 compatibility

### DIFF
--- a/packages/rpc/src/services/network.ts
+++ b/packages/rpc/src/services/network.ts
@@ -26,9 +26,6 @@ class Network {
 
         Managers.configManager.setFromPreset(options.network);
 
-        const height = await this.getHeight();
-        Managers.configManager.setHeight(height);
-
         this.checkForAip11Enabled();
     }
 


### PR DESCRIPTION
Adds a check for aip11 and sets a nonce if the milestone is reached. Uses a `setTimeout` to check every `blocktime` seconds for the new height. Once the aip11 height is reached, no new call is made

Tested it on mainnet and it could send a transaction: https://explorer.ark.io/transaction/d17782caa59c92ece2c6e7dc9fecff7c884508e8186ab77a6ce2827375c0a0ea