### PR TITLE
fix: remove redundant height call for milestone

### DIFF
--- a/packages/rpc/src/utils/transactions.ts
+++ b/packages/rpc/src/utils/transactions.ts
@@ -29,7 +29,7 @@ const buildTransaction = async (
         }
     }
 
-    const milestone = Managers.configManager.getMilestone(await network.getHeight());
+    const milestone = Managers.configManager.getMilestone();
     if (milestone.aip11) {
         // If AIP11 is enabled, get the nonce of the sender wallet
         const senderAddress: string =


### PR DESCRIPTION
Removes redundant call to fetch the height as the height is already set on startup